### PR TITLE
UTF8 + Undefined offset

### DIFF
--- a/SoustitreDownloader.php
+++ b/SoustitreDownloader.php
@@ -320,11 +320,13 @@ class addictedSubtitle extends sourceSubtitle {
 				$resultVersion = array();
 				$dec = explode("/", $l);
 				preg_match_all("#saveFavorite\(".$dec[0].",8,[0-9]*\)(.*)\/".$mod.$dec[0]."\/".$dec[1]."\"#msui", $b, $resultComplet);
-				if (!preg_match("#([0-9]*\.[0-9]*% Completed)#msui", $resultComplet[1][0])) {
-					$completedLink[] = str_replace("\/", "/",$mod).$l;
-				}
-				else {
-					$valid = false;
+				if (isset($resultComplet[1][0])) {
+					if (!preg_match("#([0-9]*\.[0-9]*% Completed)#msui", $resultComplet[1][0])) {
+						$completedLink[] = str_replace("\/", "/",$mod).$l;
+					}
+					else {
+						$valid = false;
+					}
 				}
 
 				if ($this->search->version!="") {


### PR DESCRIPTION
**UTF8**
En lançant le script depuis une VM anglaise, des caractères spéciaux s'affichaient ("Un sous-titre a ▒t▒ trouv▒") à cause de l'encodage du fichier. 

**Undefined offset**
En lançant la recherche j'avais droit à cette notification:
PHP Notice:  Undefined offset: 0 in /var/www/github/SoustitreDownloader/SoustitreDownloader.php on line 323
Il suffit de faire un ifset sur le tableau des matches pour l'annuler.
